### PR TITLE
Add --dataset_name to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Just pass --namespace logicstar to the SWE-Bench harness. Example:
 
 ```bash
 python -m swebench.harness.run_evaluation \
+    --dataset_name princeton-nlp/SWE-bench_Verified \
     --predictions_path gold \
     --max_workers 1 \
     --run_id validate-gold \


### PR DESCRIPTION
The provided zst archive is for 500 princeton-nlp/SWE-bench_Verified images, without `--dataset_name` argument to the swebench-harness it runs princeton-nlp/SWE-bench_lite instead. Added to clear up confusion.